### PR TITLE
When label is not specified in UI, it is undefined when calling sendTask.  handle this case

### DIFF
--- a/src/features/send/index.ts
+++ b/src/features/send/index.ts
@@ -37,7 +37,7 @@ export const sendTask = async ({
       ? `[Link to Logseq](logseq://graph/${currGraphName}?block-id=${uuid})`
       : '',
     ...(project !== '--- ---' && { projectId: getIdFromString(project) }),
-    ...(label[0] !== '--- ---' && {
+    ...(label && label[0] !== '--- ---' && {
       labels: label.map((l) => getNameFromString(l)),
     }),
     ...(priority && { priority: parseInt(priority) }),


### PR DESCRIPTION
When "Todoist: Send Task (manual)" is invoked and label is not specified, the UI shows "Task sent to Todoist" but doesn't show "Task sent successfully", and the task doesn't appear in todoist. 

There's a silent failure logged in developer console:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
```

when sendObj is being created and it isn't caught and shown in UI.  That is due to label having value undefined.