### PR TITLE
Use key to ensure SendTask is rerendered when content changes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,6 +81,7 @@ const main = async () => {
 
       root.render(
         <SendTask
+          key={e.uuid}
           content={content}
           projects={allProjects}
           labels={allLabels}
@@ -120,6 +121,7 @@ const main = async () => {
 
       root.render(
         <SendTask
+          key={e.uuid}
           content={content}
           projects={allProjects}
           labels={allLabels}


### PR DESCRIPTION
The useForm hook in SendTask is not rerendered when content changes.

This results in the useForm defaultValue for all subsequent renders having the values of the first block that was selected, resulting in the same task title being sent to the server each time.